### PR TITLE
Add ginabot to default no refund list

### DIFF
--- a/config-example.json
+++ b/config-example.json
@@ -24,7 +24,7 @@
   "currencies_accepted": ["SBD", "STEEM"],
   "refunds_enabled": true,
   "min_refund_amount": 0.002,
-  "no_refund": ["bittrex", "poloniex", "openledger", "blocktrades", "minnowbooster"],
+  "no_refund": ["bittrex", "poloniex", "openledger", "blocktrades", "minnowbooster", "ginabot"],
   "flag_signal_accounts": ["spaminator", "cheetah", "steemcleaners", "mack-bot", "blacklist-a"],
   "comment_location": "comment.md",
   "blacklist_location": "blacklist",


### PR DESCRIPTION
I suggest adding `ginabot` to the no refund list in the config-example.json file.  Ginabot is becoming more popular and it will prevent ping-pong loops that keep happening to new owners as they don't think of the scenario of ginabot auto refunding and them auto refunding back.

`min_refund_amount` was requested as a way to prevent this as well, but would be good to have it there if it is not configured.