### PR TITLE
Save current state before exit (fix wrong refunds on restart)

### DIFF
--- a/postpromoter.js
+++ b/postpromoter.js
@@ -660,7 +660,7 @@ function saveState() {
   };
 
   // Save the state of the bot to disk
-  fs.writeFile('state.json', JSON.stringify(state), function (err) {
+  fs.writeFileSync('state.json', JSON.stringify(state), function (err) {
     if (err)
       utils.log(err);
   });

--- a/postpromoter.js
+++ b/postpromoter.js
@@ -1136,3 +1136,12 @@ function checkErrors() {
   error_count = 0;
 }
 setInterval(checkErrors, 60 * 1000);
+
+function handle_exit_signals(signal) {
+  utils.log(`Received ${signal}. Shutting down`);
+  saveState();
+  process.exit();
+}
+
+process.on('SIGINT', handle_exit_signals.bind(null, 'SIGINT'));
+process.on('SIGTERM', handle_exit_signals.bind(null, 'SIGTERM'));


### PR DESCRIPTION
This is related to #68 & fixes wrong refunds being issued after process restart.

I got bitten by this bug on https://steemit.com/@noicebot/transfers, during last 10 days it refunded many users twice. Problem seems to be that when process is killed/restarted, `state.json` isn't saved.
 
Thus, I think it's good idea to save current state before bot is stopped. This works when it is gracefully closed eg. `Ctl + C`, `kill` etc (but not when doing force quit)

I also had to change to `fs.writeFileSync` otherwise process exits before write is complete. 